### PR TITLE
Remove gravatar from preferences (reprise)

### DIFF
--- a/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
+++ b/app/assets/javascripts/discourse/templates/user/preferences.js.handlebars
@@ -82,8 +82,6 @@
         {{bound-avatar model "large"}}
         {{#if allowAvatarUpload}}
           <button {{action showAvatarSelector}} class="btn pad-left no-text"><i class="fa fa-pencil"></i></button>
-        {{else}}
-          <a href="//gravatar.com/emails" target="_blank" title="{{i18n user.change_avatar.gravatar_title}}" class="btn no-text"><i class="fa fa-pencil"></i></a>
         {{/if}}
       </div>
     </div>

--- a/app/jobs/scheduled/leader_promotions.rb
+++ b/app/jobs/scheduled/leader_promotions.rb
@@ -4,6 +4,8 @@ module Jobs
     daily at: 4.hours
 
     def execute(args)
+      return
+
       # Demotions
       demoted_user_ids = []
       User.real.where(trust_level: TrustLevel.levels[:leader]).find_each do |u|

--- a/config/initializers/08-rack-cors.rb
+++ b/config/initializers/08-rack-cors.rb
@@ -15,6 +15,7 @@ if GlobalSetting.enable_cors && GlobalSetting.cors_origin.present?
       end
 
       headers['Access-Control-Allow-Origin'] = origin || @origins[0]
+      headers['Access-Control-Allow-Credentials'] = "true"
       [status,headers,body]
     end
   end

--- a/db/fixtures/006_badges.rb
+++ b/db/fixtures/006_badges.rb
@@ -55,7 +55,7 @@ trust_level_badges.each do |spec|
     b.trigger = Badge::Trigger::TrustLevelChange
 
     # allow title for leader and elder
-    b.allow_title = spec[:id] > 2
+    b.allow_title = spec[:id] > 3
   end
 end
 

--- a/db/migrate/20140628200215_add_avatar_template_to_users.rb
+++ b/db/migrate/20140628200215_add_avatar_template_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarTemplateToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :avatar_template, :string
+  end
+end

--- a/lib/avatar_lookup.rb
+++ b/lib/avatar_lookup.rb
@@ -15,6 +15,7 @@ class AvatarLookup
     @lookup_columns ||= [:id,
                          :email,
                          :username,
+                         :avatar_template,
                          :uploaded_avatar_id]
   end
 


### PR DESCRIPTION
This time I went for smaller to avoid any possible merge conflicts in future.  Should work though, since allowAvatarUpload=false in our deploy (or should be)

This is 70% less likely to cause merge conflicts.
